### PR TITLE
feat: adding support for day of week selection

### DIFF
--- a/app/components/habit-edit.tsx
+++ b/app/components/habit-edit.tsx
@@ -69,7 +69,7 @@ export function HabitEdit() {
                     <ul className="grid w-full grid-cols-2 gap-2 mt-5">
                       {Object.keys(days).map(day => (
                         <li key={day}>
-                          <span data-day={day} onClick={toggleDay} className={`inline-flex items-center justify-center w-full p-2 text-sm font-medium text-center border rounded-lg cursor-pointer text-blue-600 border-blue-600 dark:border-blue-500 dark:peer-checked:border-blue-500 peer-checked:border-blue-600 peer-checked:bg-blue-600 peer-checked:text-white dark:text-blue-500 dark:bg-gray-900  dark:peer-checked:bg-blue-500${days[day] ? ' dark:text-white text-white bg-blue-500 dark:bg-blue-600 dark:border-blue-600' : ' bg-white'}`}>
+                          <span data-day={day} onClick={toggleDay} className={`inline-flex items-center justify-center w-full p-2 text-sm font-medium text-center border rounded-lg cursor-pointer text-blue-600 border-blue-600${days[day] ? ' text-white bg-blue-500' : ' bg-white'}`}>
                             {DAY_LOOKUP[day]}
                           </span>
                         </li>

--- a/app/components/habit-edit.tsx
+++ b/app/components/habit-edit.tsx
@@ -1,40 +1,26 @@
 import React from 'react';
-import {useSortable} from '@dnd-kit/sortable';
-import {CSS} from '@dnd-kit/utilities';
-import { RxDragHandleHorizontal } from "react-icons/rx";
-// import { FaTrashAlt } from "react-icons/fa";
-import { useHabits } from '../providers/habits';
-
-type DayToggles = {
-  mon: boolean;
-  tues: boolean;
-  wed: boolean;
-  thu: boolean;
-  fri: boolean;
-  sat: boolean;
-  sun: boolean;
-};
+import { useHabits, DayToggles } from '../providers/habits';
 
 const DAY_LOOKUP = {
-  mon: 'Monday',
-  tues: 'Tuesday',
-  wed: 'Wednesday',
-  thu: 'Thursday',
-  fri: 'Friday',
-  sat: 'Saturday',
-  sun: 'Sunday'
+  Mon: 'Monday',
+  Tue: 'Tuesday',
+  Wed: 'Wednesday',
+  Thu: 'Thursday',
+  Fri: 'Friday',
+  Sat: 'Saturday',
+  Sun: 'Sunday'
 };
 
 export function HabitEdit() {
   const habits = useHabits();
   const [days, setDays] = React.useState<DayToggles>({
-    mon: false,
-    tues: false,
-    wed: false,
-    thu: false,
-    fri: false,
-    sat: false,
-    sun: false
+    Mon: false,
+    Tue: false,
+    Wed: false,
+    Thu: false,
+    Fri: false,
+    Sat: false,
+    Sun: false
   });
 
   function cancel() {

--- a/app/components/habit-edit.tsx
+++ b/app/components/habit-edit.tsx
@@ -41,8 +41,11 @@ export function HabitEdit() {
       setId(habits.currentlyEditing.id);
       setName(habits.currentlyEditing.name);
       let allDaysSet = true;
-      for (const toggle of Object.values(habits.currentlyEditing.days)) {
-        if (!toggle) allDaysSet = false;
+      // Handle the case where the days is null:
+      if (habits.currentlyEditing.days) {
+        for (const toggle of Object.values(habits.currentlyEditing.days)) {
+          if (!toggle) allDaysSet = false;
+        }
       }
       if (!allDaysSet) {
         setDays(JSON.parse(JSON.stringify(habits.currentlyEditing.days)));

--- a/app/components/habit-edit.tsx
+++ b/app/components/habit-edit.tsx
@@ -69,7 +69,7 @@ export function HabitEdit() {
                     <ul className="grid w-full grid-cols-2 gap-2 mt-5">
                       {Object.keys(days).map(day => (
                         <li key={day}>
-                          <span data-day={day} onClick={toggleDay} className={`inline-flex items-center justify-center w-full p-2 text-sm font-medium text-center border rounded-lg cursor-pointer text-blue-600 border-blue-600 dark:hover:text-white dark:border-blue-500 dark:peer-checked:border-blue-500 peer-checked:border-blue-600 peer-checked:bg-blue-600 hover:text-white peer-checked:text-white hover:bg-blue-500 dark:text-blue-500 dark:bg-gray-900 dark:hover:bg-blue-600 dark:hover:border-blue-600 dark:peer-checked:bg-blue-500${days[day] ? ' dark:text-white text-white bg-blue-500 dark:bg-blue-600 dark:border-blue-600' : ' bg-white'}`}>
+                          <span data-day={day} onClick={toggleDay} className={`inline-flex items-center justify-center w-full p-2 text-sm font-medium text-center border rounded-lg cursor-pointer text-blue-600 border-blue-600 dark:border-blue-500 dark:peer-checked:border-blue-500 peer-checked:border-blue-600 peer-checked:bg-blue-600 peer-checked:text-white dark:text-blue-500 dark:bg-gray-900  dark:peer-checked:bg-blue-500${days[day] ? ' dark:text-white text-white bg-blue-500 dark:bg-blue-600 dark:border-blue-600' : ' bg-white'}`}>
                             {DAY_LOOKUP[day]}
                           </span>
                         </li>

--- a/app/components/habit-list-item.tsx
+++ b/app/components/habit-list-item.tsx
@@ -25,29 +25,35 @@ export function HabitListItem(props) {
     console.info(props.id);
     habits.setEditing(true);
   }
-  
+
+  function hideRow() {
+    return props.disabled === true && props.days[habits.currentDayOfWeek] === false;
+  }
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
   };
   return (
-    <div ref={setNodeRef} style={style} {...attributes}>
-      <div className='flex w-full bg-white text-gray-800 py-2 px-4 border border-gray-400 rounded shadow habit-item disable-touch' >
-        <div {...listeners} className="w-8 mr-2">
-          {props.disabled ? '' : <RxDragHandleHorizontal className="mt-1 size-6" />}
-        </div>
-        <div className='w-5/6 mt-0.5'>
-          {props.name}
-        </div>
-        <div className='w-1/6 text-right'>
-          <div className="flex w-full">
-            <div className='w-2/4' />
-            <div className='w-2/4'>
-              {props.disabled ? <input type="checkbox" checked={props.status} onChange={handleChange} className={'w-4 h-4 mt-2'} /> : <FiEdit className='mt-1 ml-10 size-6'  onClick={handleEdit} />}
+    hideRow() ? '' : (
+      <div ref={setNodeRef} style={style} {...attributes}>
+        <div className='flex w-full bg-white text-gray-800 py-2 px-4 border border-gray-400 rounded shadow habit-item disable-touch' >
+          <div {...listeners} className="w-8 mr-2">
+            {props.disabled ? '' : <RxDragHandleHorizontal className="mt-1 size-6" />}
+          </div>
+          <div className='w-5/6 mt-0.5'>
+            {props.name}
+          </div>
+          <div className='w-1/6 text-right'>
+            <div className="flex w-full">
+              <div className='w-2/4' />
+              <div className='w-2/4'>
+                {props.disabled ? <input type="checkbox" checked={props.status} onChange={handleChange} className={'w-4 h-4 mt-2'} /> : <FiEdit className='mt-1 size-6'  onClick={handleEdit} />}
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    )
   );
 }

--- a/app/components/habit-list-item.tsx
+++ b/app/components/habit-list-item.tsx
@@ -42,11 +42,8 @@ export function HabitListItem(props) {
         <div className='w-1/6 text-right'>
           <div className="flex w-full">
             <div className='w-2/4' />
-            <div className='w-1/4'>
-              {props.disabled ? '' : <FiEdit className='mt-1 size-6'  onClick={handleEdit} />}
-            </div>
-            <div className='w-1/4'>
-              <input type="checkbox" checked={props.status} onChange={handleChange} className={'w-4 h-4 mt-2'} />
+            <div className='w-2/4'>
+              {props.disabled ? <input type="checkbox" checked={props.status} onChange={handleChange} className={'w-4 h-4 mt-2'} /> : <FiEdit className='mt-1 ml-10 size-6'  onClick={handleEdit} />}
             </div>
           </div>
         </div>

--- a/app/components/habit-list-item.tsx
+++ b/app/components/habit-list-item.tsx
@@ -22,8 +22,7 @@ export function HabitListItem(props) {
   }
 
   async function handleEdit() {
-    console.info(props.id);
-    habits.setEditing(true);
+    habits.setEditing(true, props.id);
   }
 
   function hideRow() {

--- a/app/components/habit-list-item.tsx
+++ b/app/components/habit-list-item.tsx
@@ -27,7 +27,8 @@ export function HabitListItem(props) {
   }
 
   function hideRow() {
-    return props.disabled === true && props.days[habits.currentDayOfWeek] === false;
+    const habitAppliesToDay = !props.days || props.days[habits.currentDayOfWeek];
+    return props.disabled === true && habitAppliesToDay === false;
   }
 
   const style = {

--- a/app/providers/__mocks__/habits.tsx
+++ b/app/providers/__mocks__/habits.tsx
@@ -5,11 +5,16 @@ export interface HabitType {
   id: string;
 }
 
+export interface HabitResponse {
+  current_dow: string;
+  habits: Array<HabitType>;
+}
+
 interface HabitsType {
   habits: Array<HabitType>;
   load: () => Promise<void>;
   create: (type: string) => Promise<void>;
-  set: (habits: Array<HabitType>) => {};
+  set: (habits: HabitResponse) => {};
   remove: (prefix: string, created: number) => Promise<void>;
 }
 
@@ -21,7 +26,7 @@ export type Props = {
 interface HabitsType {
   habits: Array<HabitType>;
   create: (type: string) => Promise<void>;
-  set: (habits: Array<HabitType>) => {};
+  set: (habits: HabitResponse) => {};
   remove: (prefix: string, created: number) => Promise<void>;
 }
 

--- a/app/providers/__mocks__/habits.tsx
+++ b/app/providers/__mocks__/habits.tsx
@@ -1,4 +1,14 @@
-import React, { createContext, ReactNode, useContext } from 'react';
+import React, { ReactNode } from 'react';
+
+export const NO_DAYS_SET = {
+  Mon: false,
+  Tue: false,
+  Wed: false,
+  Thu: false,
+  Fri: false,
+  Sat: false,
+  Sun: false
+};
 
 export interface HabitType {
   name: string;

--- a/app/routes/__tests__/habits.test.jsx
+++ b/app/routes/__tests__/habits.test.jsx
@@ -24,7 +24,8 @@ test("renders habits", async () => {
   ]);
   render(
     <HabitsProvider testValue={{
-      habits: [{id: 'abc123', habit_id: 'abc123', name: 'be awesome'}],
+      habits: [{id: 'abc123', habit_id: 'abc123', name: 'be awesome', days: {Mon: true}}],
+      currentDayOfWeek: 'Mon',
       load: async () => {}
     }}>
       <HabitStub />

--- a/app/routes/habits.tsx
+++ b/app/routes/habits.tsx
@@ -148,8 +148,8 @@ export default function Habits() {
                 <input type="submit" value="Add Habit" className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 ml-1 mt-1 rounded focus:outline-none focus:shadow-outline w-2/6' />
               </div>
               <ul className='flex w-full'>
-                {Object.keys(days).map(day => (
-                  <li data-day={day} onClick={toggleDay} className={`p-1 ml-1 text-sm font-medium text-center border rounded-lg cursor-pointer text-blue-600 border-blue-600 dark:border-blue-500 dark:peer-checked:border-blue-500 peer-checked:border-blue-600 peer-checked:bg-blue-600 peer-checked:text-white  dark:text-blue-500 dark:bg-gray-900 dark:peer-checked:bg-blue-500${days[day] ? ' dark:text-white text-white bg-blue-500 dark:bg-blue-600 dark:border-blue-600' : ' bg-white'}`}>
+                {Object.keys(days).map((day, i) => (
+                  <li data-day={day} onClick={toggleDay} className={`p-1 ${i === 0 ? '' : 'ml-1'} text-sm font-medium text-center border rounded-lg cursor-pointer text-blue-600 border-blue-600${days[day] ? ' text-white bg-blue-500' : ' bg-white'}`}>
                     {DAY_LOOKUP[day]}
                   </li>
                 ))}

--- a/app/routes/habits.tsx
+++ b/app/routes/habits.tsx
@@ -20,6 +20,26 @@ import { HabitListItem } from '../components/habit-list-item';
 import { HabitEdit } from '../components/habit-edit';
 import { useHabits } from '../providers/habits';
 
+type DayToggles = {
+  mon: boolean;
+  tues: boolean;
+  wed: boolean;
+  thu: boolean;
+  fri: boolean;
+  sat: boolean;
+  sun: boolean;
+};
+
+const DAY_LOOKUP = {
+  mon: 'Mon',
+  tues: 'Tue',
+  wed: 'Wed',
+  thu: 'Thu',
+  fri: 'Fri',
+  sat: 'Sat',
+  sun: 'Sun'
+};
+
 export async function loader({request}) {
   await requireUserId(request);
   return {}
@@ -29,6 +49,15 @@ export default function Habits() {
   const habits = useHabits();
   const [initialLoad, setInitialLoad] = useState<boolean>(true);
   const [sorting, setSorting] = useState<boolean>(false);
+  const [days, setDays] = React.useState<DayToggles>({
+    mon: false,
+    tues: false,
+    wed: false,
+    thu: false,
+    fri: false,
+    sat: false,
+    sun: false
+  });
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(TouchSensor),
@@ -72,6 +101,14 @@ export default function Habits() {
       await habits.load();
     }
   }
+  
+  function toggleDay(e) {
+    const toggledDay = !days[e.target.dataset.day];
+    setDays(prevDays => {
+      prevDays[e.target.dataset.day] = toggledDay;
+      return {...prevDays}
+    });
+  }
 
   return (
     <Suspense>
@@ -103,13 +140,20 @@ export default function Habits() {
             </SortableContext>
           </DndContext>
           {(sorting || habits.empty) ? (
-            <form onSubmit={createDailyHabit} className='flex w-full'>
-              <div className='w-4/6 mt-1'>
-                <input autoComplete={'off'} name="name" type="text" className='shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-normal focus:outline-none focus:shadow-outline' />
+            <form onSubmit={createDailyHabit}>
+              <div className='flex w-full'>
+                <div className='w-4/6 mt-1'>
+                  <input autoComplete={'off'} name="name" type="text" className='shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-normal focus:outline-none focus:shadow-outline' />
+                </div>
+                <input type="submit" value="Add Habit" className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 ml-1 mt-1 rounded focus:outline-none focus:shadow-outline w-2/6' />
               </div>
-              <div>
-                <input type="submit" value="Add Habit" className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 ml-1 mt-1 rounded focus:outline-none focus:shadow-outline w-full' />
-              </div>
+              <ul className='flex w-full'>
+                {Object.keys(days).map(day => (
+                  <li data-day={day} onClick={toggleDay} className={`p-1 ml-1 text-sm font-medium text-center border rounded-lg cursor-pointer text-blue-600 border-blue-600 dark:border-blue-500 dark:peer-checked:border-blue-500 peer-checked:border-blue-600 peer-checked:bg-blue-600 peer-checked:text-white  dark:text-blue-500 dark:bg-gray-900 dark:peer-checked:bg-blue-500${days[day] ? ' dark:text-white text-white bg-blue-500 dark:bg-blue-600 dark:border-blue-600' : ' bg-white'}`}>
+                    {DAY_LOOKUP[day]}
+                  </li>
+                ))}
+              </ul>
             </form>
           ) : ''}
           <label className="mt-3 inline-flex items-center cursor-pointer">

--- a/app/routes/habits.tsx
+++ b/app/routes/habits.tsx
@@ -18,26 +18,16 @@ import {
 } from '@dnd-kit/sortable';
 import { HabitListItem } from '../components/habit-list-item';
 import { HabitEdit } from '../components/habit-edit';
-import { useHabits } from '../providers/habits';
-
-type DayToggles = {
-  mon: boolean;
-  tues: boolean;
-  wed: boolean;
-  thu: boolean;
-  fri: boolean;
-  sat: boolean;
-  sun: boolean;
-};
+import { useHabits, DayToggles } from '../providers/habits';
 
 const DAY_LOOKUP = {
-  mon: 'Mon',
-  tues: 'Tue',
-  wed: 'Wed',
-  thu: 'Thu',
-  fri: 'Fri',
-  sat: 'Sat',
-  sun: 'Sun'
+  Mon: 'Mon',
+  Tue: 'Tue',
+  Wed: 'Wed',
+  Thu: 'Thu',
+  Fri: 'Fri',
+  Sat: 'Sat',
+  Sun: 'Sun'
 };
 
 export async function loader({request}) {
@@ -50,13 +40,13 @@ export default function Habits() {
   const [initialLoad, setInitialLoad] = useState<boolean>(true);
   const [sorting, setSorting] = useState<boolean>(false);
   const [days, setDays] = React.useState<DayToggles>({
-    mon: false,
-    tues: false,
-    wed: false,
-    thu: false,
-    fri: false,
-    sat: false,
-    sun: false
+    Mon: false,
+    Tue: false,
+    Wed: false,
+    Thu: false,
+    Fri: false,
+    Sat: false,
+    Sun: false
   });
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -74,7 +64,7 @@ export default function Habits() {
   async function createDailyHabit(e) {
     e.preventDefault();
     const name = e.target.name.value;
-    await habits.create(name);
+    await habits.create(name, days);
     await habits.load();
     e.target.reset();
   }
@@ -96,7 +86,10 @@ export default function Habits() {
       }
     }
     if (oldIndex !== newIndex) {
-      habits.set(arrayMove(habits.habits, oldIndex, newIndex));
+      habits.set({
+        habits: arrayMove(habits.habits, oldIndex, newIndex),
+        current_dow: habits.currentDayOfWeek
+      });
       await habits.move(oldIndex, newIndex);
       await habits.load();
     }
@@ -136,7 +129,7 @@ export default function Habits() {
               items={habits.habits}
               strategy={verticalListSortingStrategy}
             >
-              {habits.habits.map(habit => <HabitListItem name={habit.name} key={habit.habit_id} id={habit.habit_id} status={habit.status} disabled={!sorting} />)}
+              {habits.habits.map(habit => <HabitListItem name={habit.name} key={habit.habit_id} id={habit.habit_id} status={habit.status} days={habit.days} disabled={!sorting} />)}
             </SortableContext>
           </DndContext>
           {(sorting || habits.empty) ? (
@@ -149,7 +142,7 @@ export default function Habits() {
               </div>
               <ul className='flex w-full'>
                 {Object.keys(days).map((day, i) => (
-                  <li data-day={day} onClick={toggleDay} className={`p-1 ${i === 0 ? '' : 'ml-1'} text-sm font-medium text-center border rounded-lg cursor-pointer text-blue-600 border-blue-600${days[day] ? ' text-white bg-blue-500' : ' bg-white'}`}>
+                  <li data-day={day} key={day} onClick={toggleDay} className={`p-1 ${i === 0 ? '' : 'ml-1'} text-sm font-medium text-center border rounded-lg cursor-pointer text-blue-600 border-blue-600${days[day] ? ' text-white bg-blue-500' : ' bg-white'}`}>
                     {DAY_LOOKUP[day]}
                   </li>
                 ))}

--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -95,7 +95,6 @@ async function init() {
 
   app.post('/v1/habits', (req, res, next) => helpers.authenticated(req, res, next), async (req, res) => {
     const date = (new Date()).toLocaleString('lt', { timeZone: 'America/New_York' }).split(' ')[0];
-    const dow = (new Date()).toLocaleString('en-GB', { timeZone: 'America/New_York', weekday: 'short' });
     const {
       name, days = {
         Mon: true,
@@ -125,17 +124,13 @@ async function init() {
         // Also insert into the daily habits table:
         // TODO: we should make sure we populate the other habits
         // if the habits haven't yet been created for the day.
-        // Note: only populate if no day of week is set for habit, or if the
-        // habit does apply on this day of the week.
-        if (typeof days === 'undefined' || days[dow]) {
-          await txn('habits_daily').insert({
-            date,
-            name,
-            user_id: req.userId,
-            habit_id: id,
-          });
-        }
-
+        await txn('habits_daily').insert({
+          date,
+          name,
+          days,
+          user_id: req.userId,
+          habit_id: id,
+        });
         // Get the maximum position:
         const habits = await txn('habits_active_position')
           .where('user_id', req.userId)
@@ -206,6 +201,7 @@ async function init() {
 
   app.get('/v1/habits-daily', (req, res, next) => helpers.authenticated(req, res, next), async (req, res) => {
     let status = 200;
+    const dow = (new Date()).toLocaleString('en-GB', { timeZone: 'America/New_York', weekday: 'short' });
     const data = await Sentry.startSpan(
       {
         name: 'fetch cached daily habits',
@@ -224,14 +220,14 @@ async function init() {
           return cachedValue;
         }
         let habitsDaily = await db('habits_daily')
-          .select(['name', 'status', 'habit_id', 'status', 'date'])
+          .select(['name', 'status', 'habit_id', 'status', 'date', 'days'])
           .where('habits_daily.date', date)
           .where('habits_daily.user_id', req.userId);
         // If no habits have been created yet for the given day
         // populate for the day.
         if (habitsDaily.length === 0) {
           const habits = await db('habits')
-            .select(['name', 'id'])
+            .select(['name', 'days', 'id'])
             .where('habits.user_id', req.userId)
             .where('habits.active', true);
           // No daily habits have been created yet to copy:
@@ -241,6 +237,7 @@ async function init() {
           habitsDaily = habits.map((habit) => ({
             name: habit.name,
             date,
+            days: habit.days,
             habit_id: habit.id,
             user_id: req.userId,
             status: false,
@@ -275,7 +272,10 @@ async function init() {
       },
     );
     res.type('json');
-    res.status(status).send(data);
+    res.status(status).send({
+      habits: data,
+      current_dow: dow,
+    });
   });
 
   app.get('/v1/callback', async (req, res) => {

--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -95,7 +95,18 @@ async function init() {
 
   app.post('/v1/habits', (req, res, next) => helpers.authenticated(req, res, next), async (req, res) => {
     const date = (new Date()).toLocaleString('lt', { timeZone: 'America/New_York' }).split(' ')[0];
-    const { name } = req.body;
+    const dow = (new Date()).toLocaleString('en-GB', { timeZone: 'America/New_York', weekday: 'short' });
+    const {
+      name, days = {
+        Mon: true,
+        Tue: true,
+        Wed: true,
+        Thu: true,
+        Fri: true,
+        Sat: true,
+        Sun: true,
+      },
+    } = req.body;
     if (!name) {
       const status = 422;
       res.status(status).send(JSON.stringify({
@@ -108,17 +119,22 @@ async function init() {
         const insertHabitResp = (await txn('habits').insert({
           name,
           user_id: req.userId,
+          days,
         }, ['id']))[0];
         id = insertHabitResp.id;
         // Also insert into the daily habits table:
         // TODO: we should make sure we populate the other habits
         // if the habits haven't yet been created for the day.
-        await txn('habits_daily').insert({
-          date,
-          name,
-          user_id: req.userId,
-          habit_id: id,
-        });
+        // Note: only populate if no day of week is set for habit, or if the
+        // habit does apply on this day of the week.
+        if (typeof days === 'undefined' || days[dow]) {
+          await txn('habits_daily').insert({
+            date,
+            name,
+            user_id: req.userId,
+            habit_id: id,
+          });
+        }
 
         // Get the maximum position:
         const habits = await txn('habits_active_position')

--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -159,6 +159,39 @@ async function init() {
     }
   });
 
+  app.put('/v1/habits/:id', (req, res, next) => helpers.authenticated(req, res, next), async (req, res) => {
+    const { name, days } = req.body;
+    const date = (new Date()).toLocaleString('lt', { timeZone: 'America/New_York' }).split(' ')[0];
+    if (!name) {
+      const status = 422;
+      res.status(status).send(JSON.stringify({
+        status,
+        error: 'missing name',
+      }));
+    } else {
+      await db.transaction(async (txn) => {
+        const update = {
+          name,
+        };
+        if (days) update.days = JSON.stringify(days);
+        await txn('habits')
+          .where('id', req.params.id)
+          .update(update);
+        await txn('habits_daily')
+          .where('habit_id', req.params.id)
+          .where('date', date)
+          .update(update);
+      });
+      res.type('json');
+      const status = 200;
+      req.session[CACHED_HABITS_SESSION_KEY] = null;
+      res.status(status).send(JSON.stringify({
+        status,
+        id: req.params.id,
+      }));
+    }
+  });
+
   app.post('/v1/habits/array-move', (req, res, next) => helpers.authenticated(req, res, next), async (req, res) => {
     // const collection = client.db().collection('collection');
     // console.info(await collection.insertOne({ _id: randomUUID(), batman: 'Caped Crusader' }));

--- a/lib/helpers/instrument.mjs
+++ b/lib/helpers/instrument.mjs
@@ -6,7 +6,7 @@ if (!isTestEnvironment) {
   Sentry.init({
     debug: true,
     environment: process.env.NODE_ENV,
-    dsn: 'https://13965dffbb716e9acd13a3f8da18b25a@o4507380538540032.ingest.us.sentry.io/4507409421762560',
+    dsn: 'https://1f3d2fd796551fb369012ca770646223@o4506956365430784.ingest.us.sentry.io/4506956389416960',
     integrations: [
       // enable HTTP calls tracing
       // new Sentry.Integrations.Http({ tracing: true }),

--- a/lib/worker.mjs
+++ b/lib/worker.mjs
@@ -11,7 +11,7 @@ const QUEUE_KEY = 'metrics-jobs';
 
 if (!isTestEnvironment) {
   Sentry.init({
-    debug: true,
+    // debug: true,
     environment: process.env.NODE_ENV,
     dsn: 'https://e8c6953f82f7bdadbab491d4fb2c8caf@o4506956365430784.ingest.us.sentry.io/4506956389416960',
     integrations: [
@@ -65,18 +65,46 @@ export default function consume() {
                 const dailyBucket = Object.create(null);
                 const habits = await db('habits_daily')
                   .where('user_id', job.userId)
+                  .orderBy('date', 'asc')
                   .select();
-                habits.forEach((habit) => {
-                  const date = new Date(habit.date).toISOString().split('T')[0];
-                  dailyBucket[date] ||= {
+                // No daily habits have been entered yet:
+                if (habits.length === 0) return;
+
+                // Create lookup table by date, so that we can handle
+                // the case of days that have never had a habit_daily
+                // entry created for them.
+                const habitsLookup = Object.create(null);
+                habits.forEach((h) => {
+                  const dateString = new Date(h.date).toISOString().split('T')[0];
+                  habitsLookup[dateString] ||= [];
+                  habitsLookup[dateString].push(h);
+                });
+                // Iterate between the first date habits have been entered
+                // for and the last date habits have been entered for
+                // TODO: this is not timezone aware, fix this.
+                const dateIndex = new Date(habits[0].date);
+                const endDate = new Date(habits[habits.length - 1].date);
+                do {
+                  const dateString = new Date(dateIndex).toISOString().split('T')[0];
+                  const dow = (new Date(dateIndex)).toLocaleString('en-GB', { timeZone: 'America/New_York', weekday: 'short' });
+                  dailyBucket[dateString] ||= {
                     user_id: job.userId,
                     habits_completed: 0,
                     total_habits_for_day: 0,
-                    date,
+                    date: dateString,
                   };
-                  if (habit.status) dailyBucket[date].habits_completed += 1;
-                  dailyBucket[date].total_habits_for_day += 1;
-                });
+                  (habitsLookup[dateString] || []).forEach((habit) => {
+                    // Only increment counts if this habit applies to the given
+                    // day of the week:
+                    if (habit.days[dow]) {
+                      // If status is true, it indicates that someone completed the
+                      // habit on the given day:
+                      if (habit.status) dailyBucket[dateString].habits_completed += 1;
+                      dailyBucket[dateString].total_habits_for_day += 1;
+                    }
+                  });
+                  dateIndex.setDate(dateIndex.getDate() + 1);
+                } while (dateIndex <= endDate);
                 await Promise.all(
                   Object.keys(dailyBucket).map(async (key) => db.transaction(async (trx) => {
                     const exists = !!(await trx('daily_habit_metrics')

--- a/migrations/20240501180438_daily-habit-metrics.js
+++ b/migrations/20240501180438_daily-habit-metrics.js
@@ -14,11 +14,10 @@ export const up = function (knex) {
       });
   };
   
-  /**
-   * @param { import("knex").Knex } knex
-   * @returns { Promise<void> }
-   */
-  export const down = function (knex) {
-    return knex.schema.dropTable('daily_habit_metrics');
-  };
-  
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = function (knex) {
+  return knex.schema.dropTable('daily_habit_metrics');
+};

--- a/migrations/20240819151034_habits-add-days.cjs
+++ b/migrations/20240819151034_habits-add-days.cjs
@@ -1,0 +1,14 @@
+
+exports.up = function(knex) {
+  return knex.schema
+    .table('habits', (table) => {
+      table.json('days');
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .table('habits', (table) => {
+      table.dropColumn('days');
+    });
+};

--- a/migrations/20240819173029_habits-daily-add-days.cjs
+++ b/migrations/20240819173029_habits-daily-add-days.cjs
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema
+    .table('habits_daily', (table) => {
+      table.json('days');
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .table('habits_daily', (table) => {
+      table.dropColumn('days');
+    });
+};

--- a/test/api.mjs
+++ b/test/api.mjs
@@ -120,7 +120,7 @@ describe('api', () => {
       });
       assert.strictEqual(resp.status, 200);
       const habits = await resp.json();
-      assert.strictEqual(habits.length, 2);
+      assert.strictEqual(habits.habits.length, 2);
     });
   });
 


### PR DESCRIPTION
Habits can now be specific to certain days of week.

Editing an existing Habit:

<img width="633" alt="Screenshot 2024-08-19 at 4 58 38 PM" src="https://github.com/user-attachments/assets/7efbea8d-2287-433d-9c79-c31b07a4cbed">

Adding a new habit:

<img width="1055" alt="Screenshot 2024-08-19 at 4 56 41 PM" src="https://github.com/user-attachments/assets/ad20e18c-92a0-483f-8825-f02381610164">

TODO:

- [ ] update chart generation to take into account whether the habit applies to a given day of the week.