### PR TITLE
feat: PoC authToken based request auth

### DIFF
--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -93,6 +93,54 @@ async function init() {
   }
   app.use(session(sessionOpts));
 
+  async function getUserSessionForAuthToken(accessToken, req) {
+    const profReq = await global.fetch(`https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=${accessToken}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    const profile = await profReq.json();
+    // Check if an entry already exists for this user:
+    const results = await db('users')
+      .select('id')
+      .where('users.account_type', GOOGLE_ACCOUNT_TYPE)
+      .where('users.email', profile.email);
+    if (!results.length) {
+      const { id } = (await db('users').insert({
+        email: profile.email,
+        account_type: GOOGLE_ACCOUNT_TYPE,
+      }, ['id']))[0];
+      req.session.userId = id;
+    } else {
+      const { id } = results[0];
+      req.session.userId = id;
+    }
+  }
+
+  const helpers = {
+    async authenticated(req, res, next) {
+      req.userId = req.session.userId;
+
+      // TODO FIXME: this will fetch session for every request that only has auth token, i.e. every
+      // mobile request - should be cached in e.g. redis
+      if (!req.userId && req.headers.authorization) {
+        const authToken = req.headers.authorization.substring('Bearer '.length);
+        await getUserSessionForAuthToken(authToken, req);
+        req.userId = req.session.userId;
+      }
+
+      if (!req.userId) {
+        const status = 401;
+        return res.status(status).send(JSON.stringify({
+          status,
+          error: 'unauthorized',
+        }));
+      }
+      return next();
+    },
+  };
+
   app.post('/v1/habits', (req, res, next) => helpers.authenticated(req, res, next), async (req, res) => {
     const date = (new Date()).toLocaleString('lt', { timeZone: 'America/New_York' }).split(' ')[0];
     const {
@@ -313,28 +361,7 @@ async function init() {
 
   app.get('/v1/callback', async (req, res) => {
     const { tokens: { access_token: accessToken } } = await oAuth2Client.getToken(req.query.code);
-    const profReq = await global.fetch(`https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=${accessToken}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-    const profile = await profReq.json();
-    // Check if an entry already exists for this user:
-    const results = await db('users')
-      .select('id')
-      .where('users.account_type', GOOGLE_ACCOUNT_TYPE)
-      .where('users.email', profile.email);
-    if (!results.length) {
-      const { id } = (await db('users').insert({
-        email: profile.email,
-        account_type: GOOGLE_ACCOUNT_TYPE,
-      }, ['id']))[0];
-      req.session.userId = id;
-    } else {
-      const { id } = results[0];
-      req.session.userId = id;
-    }
+    await getUserSessionForAuthToken(accessToken, req);
     res.redirect('/habits');
   });
 

--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -46,27 +46,38 @@ let redisClient;
 // let client;
 
 async function getUserSessionForAuthToken(accessToken, req) {
-  const profReq = await global.fetch(`https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=${accessToken}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-  const profile = await profReq.json();
-  // Check if an entry already exists for this user:
-  const results = await db('users')
+  // Is there a user record associated with this access token:
+  const userByAccessToken = await db('users')
     .select('id')
-    .where('users.account_type', GOOGLE_ACCOUNT_TYPE)
-    .where('users.email', profile.email);
-  if (!results.length) {
-    const { id } = (await db('users').insert({
-      email: profile.email,
-      account_type: GOOGLE_ACCOUNT_TYPE,
-    }, ['id']))[0];
+    .where('users.access_token', accessToken);
+  if (userByAccessToken.length) {
+    const { id } = userByAccessToken[0];
     req.session.userId = id;
   } else {
-    const { id } = results[0];
-    req.session.userId = id;
+    // Okay, we seem to have an access token but haven't created a user record yet:
+    const profReq = await global.fetch(`https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=${accessToken}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    const profile = await profReq.json();
+    // Check if an entry already exists for this user:
+    const usersByEmailAccountType = await db('users')
+      .select('id')
+      .where('users.account_type', GOOGLE_ACCOUNT_TYPE)
+      .where('users.email', profile.email);
+    if (usersByEmailAccountType.length === 0) {
+      const { id } = (await db('users').insert({
+        email: profile.email,
+        account_type: GOOGLE_ACCOUNT_TYPE,
+        access_token: accessToken,
+      }, ['id']))[0];
+      req.session.userId = id;
+    } else {
+      const { id } = usersByEmailAccountType[0];
+      req.session.userId = id;
+    }
   }
 }
 

--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -40,9 +40,48 @@ if (!isTestEnvironment) {
     : await import('../build/server/index.js');
 }
 
+let db; // DB will be set when server connects.
+let oAuth2Client;
+let redisClient;
+// let client;
+
+async function getUserSessionForAuthToken(accessToken, req) {
+  const profReq = await global.fetch(`https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=${accessToken}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  const profile = await profReq.json();
+  // Check if an entry already exists for this user:
+  const results = await db('users')
+    .select('id')
+    .where('users.account_type', GOOGLE_ACCOUNT_TYPE)
+    .where('users.email', profile.email);
+  if (!results.length) {
+    const { id } = (await db('users').insert({
+      email: profile.email,
+      account_type: GOOGLE_ACCOUNT_TYPE,
+    }, ['id']))[0];
+    req.session.userId = id;
+  } else {
+    const { id } = results[0];
+    req.session.userId = id;
+  }
+}
+
 export const helpers = {
-  authenticated(req, res, next) {
+  async authenticated(req, res, next) {
     req.userId = req.session.userId;
+
+    // TODO FIXME: this will fetch session for every request that only has auth token, i.e. every
+    // mobile request - should be cached in e.g. redis
+    if (!req.userId && req.headers.authorization) {
+      const authToken = req.headers.authorization.substring('Bearer '.length);
+      await getUserSessionForAuthToken(authToken, req);
+      req.userId = req.session.userId;
+    }
+
     if (!req.userId) {
       const status = 401;
       return res.status(status).send(JSON.stringify({
@@ -54,10 +93,6 @@ export const helpers = {
   },
 };
 
-let db; // DB will be set when server connects.
-let oAuth2Client;
-let redisClient;
-// let client;
 async function init() {
   // client = new MongoClient(process.env.MONGO_URL);
   // await client.connect();
@@ -92,54 +127,6 @@ async function init() {
     sessionOpts.store = redisStore;
   }
   app.use(session(sessionOpts));
-
-  async function getUserSessionForAuthToken(accessToken, req) {
-    const profReq = await global.fetch(`https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=${accessToken}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-    const profile = await profReq.json();
-    // Check if an entry already exists for this user:
-    const results = await db('users')
-      .select('id')
-      .where('users.account_type', GOOGLE_ACCOUNT_TYPE)
-      .where('users.email', profile.email);
-    if (!results.length) {
-      const { id } = (await db('users').insert({
-        email: profile.email,
-        account_type: GOOGLE_ACCOUNT_TYPE,
-      }, ['id']))[0];
-      req.session.userId = id;
-    } else {
-      const { id } = results[0];
-      req.session.userId = id;
-    }
-  }
-
-  const helpers = {
-    async authenticated(req, res, next) {
-      req.userId = req.session.userId;
-
-      // TODO FIXME: this will fetch session for every request that only has auth token, i.e. every
-      // mobile request - should be cached in e.g. redis
-      if (!req.userId && req.headers.authorization) {
-        const authToken = req.headers.authorization.substring('Bearer '.length);
-        await getUserSessionForAuthToken(authToken, req);
-        req.userId = req.session.userId;
-      }
-
-      if (!req.userId) {
-        const status = 401;
-        return res.status(status).send(JSON.stringify({
-          status,
-          error: 'unauthorized',
-        }));
-      }
-      return next();
-    },
-  };
 
   app.post('/v1/habits', (req, res, next) => helpers.authenticated(req, res, next), async (req, res) => {
     const date = (new Date()).toLocaleString('lt', { timeZone: 'America/New_York' }).split(' ')[0];

--- a/migrations/20240820150832_add-auth-token-user.cjs
+++ b/migrations/20240820150832_add-auth-token-user.cjs
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema
+    .table('users', (table) => {
+      table.string('access_token', 2048);
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .table('users', (table) => {
+      table.dropColumn('access_token');
+    });
+};


### PR DESCRIPTION
caveats:
- we should add the accessToken to the session cache so that we don't need to ping Goole API on every request
- helpers are not exported anymore, so some tests accessing them directly fail now